### PR TITLE
Pass GEM_HOME to bootstrap env for containers

### DIFF
--- a/lib/onceover/octocatalog/diff/cli.rb
+++ b/lib/onceover/octocatalog/diff/cli.rb
@@ -93,6 +93,7 @@ revisions to compare between.
                     logger.info "Compiling catalogs for #{test.classes[0].name} on #{test.nodes[0].name}"
 
                     command_prefix = ENV['BUNDLE_GEMFILE'] ? 'bundle exec ' : ''
+                    bootstrap_env = "--bootstrap-environment GEM_HOME=#{ENV['GEM_HOME']}" if ENV['GEM_HOME'] else ''
 
                     command_args = [
                       '--fact-file',
@@ -110,7 +111,8 @@ revisions to compare between.
                       '--hiera-config',
                       repo.hiera_config_file,
                       '--pass-env-vars',
-                      ENV.keys.keep_if {|k| k =~ /^RUBY|^BUNDLE/ }.join(',')
+                      ENV.keys.keep_if {|k| k =~ /^RUBY|^BUNDLE/ }.join(','),
+                      bootstrap_env
                     ]
 
                     cmd = "#{command_prefix}octocatalog-diff #{command_args.join(' ')}"


### PR DESCRIPTION
Onceover diff runs fail in containers. The octocatalog-diff command
needs to be passed the GEM_HOME environment variable or it will fail to
import any bundler gems.

Fixes issue #9