### PR TITLE
Fix GEM_HOME and octocatalog for newer Puppet

### DIFF
--- a/lib/onceover/octocatalog/diff/cli.rb
+++ b/lib/onceover/octocatalog/diff/cli.rb
@@ -93,6 +93,7 @@ revisions to compare between.
                     logger.info "Compiling catalogs for #{test.classes[0].name} on #{test.nodes[0].name}"
 
                     command_prefix = ENV['BUNDLE_GEMFILE'] ? 'bundle exec ' : ''
+                    bootstrap_env = "--bootstrap-environment GEM_HOME=#{ENV['GEM_HOME']}" if ENV['GEM_HOME']
 
                     command_args = [
                       '--fact-file',
@@ -110,7 +111,8 @@ revisions to compare between.
                       '--hiera-config',
                       repo.hiera_config_file,
                       '--pass-env-vars',
-                      ENV.keys.keep_if {|k| k =~ /^RUBY|^BUNDLE/ }.join(',')
+                      ENV.keys.keep_if {|k| k =~ /^RUBY|^BUNDLE/ }.join(','),
+                      bootstrap_env
                     ]
 
                     cmd = "#{command_prefix}octocatalog-diff #{command_args.join(' ')}"

--- a/lib/onceover/octocatalog/diff/version.rb
+++ b/lib/onceover/octocatalog/diff/version.rb
@@ -1,7 +1,7 @@
 class Onceover
   module Octocatalog
     module Diff
-      VERSION = "0.1.8"
+      VERSION = "0.1.9"
     end
   end
 end

--- a/onceover-octocatalog-diff.gemspec
+++ b/onceover-octocatalog-diff.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", ">= 2.2.10"
   spec.add_development_dependency "rake", ">= 12.3.3"
-  spec.add_runtime_dependency 'octocatalog-diff', '~> 1.0'
-  spec.add_runtime_dependency 'onceover', '>= 3.2.0'
+  spec.add_runtime_dependency 'octocatalog-diff', '~> 2.1'
+  spec.add_runtime_dependency 'onceover', '>= 3.20.0'
 end


### PR DESCRIPTION
This is a reimplementation of https://github.com/dylanratcliffe/onceover-octocatalog-diff/pull/10 and fixes #11  and #10