### PR TITLE
Allow comparisons between modules when using 'control_branch'.

### DIFF
--- a/lib/onceover/octocatalog/diff/cli.rb
+++ b/lib/onceover/octocatalog/diff/cli.rb
@@ -111,7 +111,7 @@ revisions to compare between.
                       '--hiera-config',
                       repo.hiera_config_file,
                       '--pass-env-vars',
-                      ENV.keys.keep_if {|k| k =~ /^RUBY|^BUNDLE/ }.join(','),
+                      ENV.keys.keep_if {|k| k =~ /^RUBY|^BUNDLE|^PUPPET/ }.join(','),
                       bootstrap_env
                     ]
 

--- a/lib/onceover/octocatalog/diff/cli.rb
+++ b/lib/onceover/octocatalog/diff/cli.rb
@@ -29,62 +29,143 @@ revisions to compare between.
               @queue = tests.inject(Queue.new, :push)
               @results = []
 
+              # Create r10k_cache_dirs
+              r10k_cache_dir_from = Dir.mktmpdir('r10k_cache')
+              r10k_config = {
+                'cachedir' => r10k_cache_dir_from,
+              }
+              logger.debug "Creating r10k cache for thread at #{r10k_cache_dir_from}"
+              File.write("#{r10k_cache_dir_from}/r10k.yaml",r10k_config.to_yaml)
+
+              r10k_cache_dir_to = Dir.mktmpdir('r10k_cache')
+              r10k_config = {
+                'cachedir' => r10k_cache_dir_to,
+              }
+              logger.debug "Creating r10k cache for thread at #{r10k_cache_dir_to}"
+              File.write("#{r10k_cache_dir_to}/r10k.yaml",r10k_config.to_yaml)
+
+              # Create control repo to and from
+              fromdir = Dir.mktmpdir("control_repo")
+              logger.debug "Temp directory created at #{fromdir}"
+              todir = Dir.mktmpdir("control_repo")
+              logger.debug "Temp directory created at #{todir}"
+              logger.debug "Copying controlrepo to #{fromdir}"
+              FileUtils.copy_entry(repo.root,fromdir)
+              logger.debug "Copying controlrepo to #{todir}"
+              FileUtils.copy_entry(repo.root,todir)
+
+              # Copy all of the factsets over in reverse order so that
+              # local ones override vendored ones
+              logger.debug "Deploying vendored factsets"
+              deduped_factsets = repo.facts_files.reverse.inject({}) do |hash, file|
+                hash[File.basename(file)] = file
+                hash
+              end
+
+              deduped_factsets.each do |basename,path|
+                facts = JSON.load(File.read(path))
+                File.open("#{fromdir}/spec/factsets/#{File.basename(path,'.*')}.yaml", 'w') { |f| f.write facts.to_yaml }
+                File.open("#{todir}/spec/factsets/#{File.basename(path,'.*')}.yaml", 'w') { |f| f.write facts.to_yaml }
+              end
+
+              # Set correct branch in bootstrap dirs
+              logger.debug "Check out #{opts[:from]} branch"
+              git_from = "git checkout #{opts[:from]}"
+              Open3.popen3(git_from, :chdir => fromdir) do |stdin, stdout, stderr, wait_thr|
+                exit_status = wait_thr.value
+                if exit_status.exitstatus != 0
+                  STDOUT.puts stdout.read
+                  STDERR.puts stderr.read
+                  abort "Git checkout branch #{opts[:from]} failed. Please verify this is a valid control-repo branch"
+                end
+              end
+              logger.debug "Check out #{opts[:to]} branch"
+              git_to = "git checkout #{opts[:to]}"
+              Open3.popen3(git_to, :chdir => todir) do |stdin, stdout, stderr, wait_thr|
+                exit_status = wait_thr.value
+                if exit_status.exitstatus != 0
+                  STDOUT.puts stdout.read
+                  STDERR.puts stderr.read
+                  abort "Git checkout branch #{opts[:to]} failed. Please verify this is a valid control-repo branch"
+                end
+              end
+
+              # Update Puppetfile for control-branch
+              # r10k seems to have issues resolving the :control_branch reference in Puppetfile. Setting control_branch to actual branch as workaround.
+              frompuppetfile = "#{fromdir}/Puppetfile"
+              from_content = File.read(frompuppetfile)
+              new_content = from_content.gsub(/:control_branch/, "'#{opts[:from]}'")
+              File.open(frompuppetfile, "w") {|file| file.puts new_content }
+              topuppetfile = "#{todir}/Puppetfile"
+              to_content = File.read(topuppetfile)
+              new_content = to_content.gsub(/:control_branch/, "'#{opts[:to]}'")
+              File.open(topuppetfile, "w") {|file| file.puts new_content }
+
+              # Set correct branch in bootstrap dirs
+              logger.debug "Check out #{opts[:from]} branch"
+              git_from = "git checkout #{opts[:from]}"
+              Open3.popen3(git_from, :chdir => fromdir) do |stdin, stdout, stderr, wait_thr|
+                exit_status = wait_thr.value
+                if exit_status.exitstatus != 0
+                  STDOUT.puts stdout.read
+                  STDERR.puts stderr.read
+                  abort "Git checkout branch #{opts[:from]} failed. Please verify this is a valid control-repo branch"
+                end
+              end
+              logger.debug "Check out #{opts[:to]} branch"
+              git_to = "git checkout #{opts[:to]}"
+              Open3.popen3(git_to, :chdir => todir) do |stdin, stdout, stderr, wait_thr|
+                exit_status = wait_thr.value
+                if exit_status.exitstatus != 0
+                  STDOUT.puts stdout.read
+                  STDERR.puts stderr.read
+                  abort "Git checkout branch #{opts[:to]} failed. Please verify this is a valid control-repo branch"
+                end
+              end
+
+              # Deploy Puppetfile in from
+              logger.info "Deploying Puppetfile for from branch"
+              r10k_cmd = "r10k puppetfile install --verbose --color --puppetfile #{frompuppetfile} --config #{r10k_cache_dir_from}/r10k.yaml"
+              Open3.popen3(r10k_cmd, :chdir => fromdir) do |stdin, stdout, stderr, wait_thr|
+                exit_status = wait_thr.value
+                if exit_status.exitstatus != 0
+                  STDOUT.puts stdout.read
+                  STDERR.puts stderr.read
+                  abort "R10k encountered an error, see the logs for details"
+                end
+              end
+
+              # Deploy Puppetfile in to
+              logger.info "Deploying Puppetfile for to branch"
+              r10k_cmd = "r10k puppetfile install --verbose --color --puppetfile #{topuppetfile} --config #{r10k_cache_dir_to}/r10k.yaml"
+              Open3.popen3(r10k_cmd, :chdir => todir) do |stdin, stdout, stderr, wait_thr|
+                exit_status = wait_thr.value
+                if exit_status.exitstatus != 0
+                  STDOUT.puts stdout.read
+                  STDERR.puts stderr.read
+                  abort "R10k encountered an error, see the logs for details"
+                end
+              end
+
+
               @threads = Array.new(num_threads) do
                 Thread.new do
-                  r10k_cache_dir = Dir.mktmpdir('r10k_cache')
-                  r10k_config = {
-                    'cachedir' => r10k_cache_dir,
-                  }
-                  logger.debug "Creating r10k cache for thread at #{r10k_cache_dir}"
-                  File.write("#{r10k_cache_dir}/r10k.yaml",r10k_config.to_yaml)
-
                   until @queue.empty?
                     test = @queue.shift
 
                     logger.info "Preparing environment for #{test.classes[0].name} on #{test.nodes[0].name}"
-                    logger.debug "Creating temp directory"
-                    tempdir = Dir.mktmpdir(test.to_s)
-                    logger.debug "Temp directory created at #{tempdir}"
-
-                    logger.debug "Copying controlrepo to #{tempdir}"
-                    FileUtils.copy_entry(repo.root,tempdir)
-
-                    # Copy all of the factsets over in reverse order so that
-                    # local ones override vendored ones
-                    logger.debug "Deploying vendored factsets"
-                    deduped_factsets = repo.facts_files.reverse.inject({}) do |hash, file|
-                      hash[File.basename(file)] = file
-                      hash
-                    end
-
-                    deduped_factsets.each do |basename,path|
-                      facts = JSON.load(File.read(path))
-                      File.open("#{tempdir}/spec/factsets/#{File.basename(path,'.*')}.yaml", 'w') { |f| f.write facts.to_yaml }
-                    end
-
-                    if File.directory?("#{r10k_cache_dir}/modules")
-                      logger.debug "Copying modules from thread cache to #{tempdir}"
-                      FileUtils.copy_entry("#{r10k_cache_dir}/modules","#{tempdir}/modules")
-                    end
-
-                    logger.info "Deploying Puppetfile for #{test.classes[0].name} on #{test.nodes[0].name}"
-                    r10k_cmd = "r10k puppetfile install --verbose --color --puppetfile #{repo.puppetfile} --config #{r10k_cache_dir}/r10k.yaml"
-                    Open3.popen3(r10k_cmd, :chdir => tempdir) do |stdin, stdout, stderr, wait_thr|
-                      exit_status = wait_thr.value
-                      if exit_status.exitstatus != 0
-                        STDOUT.puts stdout.read
-                        STDERR.puts stderr.read
-                        abort "R10k encountered an error, see the logs for details"
-                      end
-                    end
 
                     # TODO: Improve the way this works so that it doesn't blat site.pp
-                    logger.debug "Creating before script that overwrites site.pp"
+                    # Update site.pp
+                    logger.debug "Updaing site.pp in from control-repo"
                     class_name = test.classes[0].name
-                    template_dir = File.expand_path('../../../../templates',File.dirname(__FILE__))
-                    template = File.read(File.expand_path("./change_manifest.rb.erb",template_dir))
-                    File.write("#{tempdir}/bootstrap_script.rb",ERB.new(template, nil, '-').result(binding))
-                    FileUtils.chmod("u=rwx","#{tempdir}/bootstrap_script.rb")
+                    control_repos = [fromdir, todir]
+
+                    control_repos.each do | file_name |
+                      tempfile = File.open("#{file_name}/manifests/site.pp", "w")
+                      tempfile.puts "include #{class_name}"
+                      tempfile.close
+                    end
 
                     logger.debug "Getting Puppet binary"
                     binary = `which puppet`.chomp
@@ -97,25 +178,23 @@ revisions to compare between.
 
                     command_args = [
                       '--fact-file',
-                      "#{tempdir}/spec/factsets/#{test.nodes[0].name}.yaml",
-                      '--from',
-                      opts[:from],
-                      '--to',
-                      opts[:to],
-                      '--basedir',
-                      tempdir,
+                      "#{fromdir}/spec/factsets/#{test.nodes[0].name}.yaml",
+                      '--bootstrapped-from-dir',
+                      fromdir,
+                      '--bootstrapped-to-dir',
+                      todir,
                       '--puppet-binary',
                       binary,
-                      '--bootstrap-script',
-                      "'#{tempdir}/bootstrap_script.rb'",
                       '--hiera-config',
                       repo.hiera_config_file,
                       '--pass-env-vars',
                       ENV.keys.keep_if {|k| k =~ /^RUBY|^BUNDLE|^PUPPET/ }.join(','),
-                      bootstrap_env
+                      bootstrap_env,
+                      '-n',
+                      test.nodes[0].name
                     ]
 
-                    cmd = "#{command_prefix}octocatalog-diff #{command_args.join(' ')} -n #{test.nodes[0].name}"
+                    cmd = "#{command_prefix}octocatalog-diff #{command_args.join(' ')}"
                     logger.debug "Running: #{cmd}"
                     Open3.popen3(cmd) do |stdin, stdout, stderr, wait_thr|
                       exit_status = wait_thr.value
@@ -127,15 +206,13 @@ revisions to compare between.
                       }
                     end
                     logger.info "Storing results for #{test.classes[0].name} on #{test.nodes[0].name}"
-
-                    logger.debug "Backing up modules to thread cache #{tempdir}"
-                    FileUtils.mv("#{tempdir}/modules","#{r10k_cache_dir}/modules",:force => true)
-
-                    logger.debug "Removing temporary build cache"
-                    FileUtils.rm_r(tempdir)
                   end
 
-                  FileUtils.rm_r(r10k_cache_dir)
+                  logger.debug "Removing temporary build cache"
+                  FileUtils.rm_r(fromdir)
+                  FileUtils.rm_r(todir)
+                  FileUtils.rm_r(r10k_cache_dir_from)
+                  FileUtils.rm_r(r10k_cache_dir_to)
                 end
               end
 

--- a/lib/onceover/octocatalog/diff/cli.rb
+++ b/lib/onceover/octocatalog/diff/cli.rb
@@ -115,7 +115,7 @@ revisions to compare between.
                       bootstrap_env
                     ]
 
-                    cmd = "#{command_prefix}octocatalog-diff #{command_args.join(' ')}"
+                    cmd = "#{command_prefix}octocatalog-diff #{command_args.join(' ')} -n #{test.nodes[0].name}"
                     logger.debug "Running: #{cmd}"
                     Open3.popen3(cmd) do |stdin, stdout, stderr, wait_thr|
                       exit_status = wait_thr.value

--- a/lib/onceover/octocatalog/diff/version.rb
+++ b/lib/onceover/octocatalog/diff/version.rb
@@ -1,7 +1,7 @@
 class Onceover
   module Octocatalog
     module Diff
-      VERSION = "0.1.9"
+      VERSION = "0.1.10"
     end
   end
 end


### PR DESCRIPTION
Fixes #14
Fixes #16  

This PR introduces some changes to how we run octocatalog-diff. We now pre-bootstrap the 'from' and 'to' directory before we call octocatalog-diff. 